### PR TITLE
fix for the ENDTCPSVR parameter value suggestions

### DIFF
--- a/server/src/spec.ts
+++ b/server/src/spec.ts
@@ -40,6 +40,7 @@ export function getPrettyDocs(docs: any): CommandDoc {
 				const info = parm[`$`];
 				const qual = parm.Qual;
 				const elem = parm.Elem ? [...parm.Elem].flatMap(item => item.SpcVal || []) : [];
+				// Union of all available valid Parmeter Values
 				const val = [...(parm.SpcVal || []), ...(parm.SngVal || []), ...(parm.ChoicePgmValues || []), ...(elem || [])].flatMap(item => item.Value);
 
 				let specialValues = [];
@@ -51,7 +52,6 @@ export function getPrettyDocs(docs: any): CommandDoc {
 				return {
 					keyword: info.Kwd,
 					prompt: info.Prompt,
-
 					choice: info.Choice,
 					type: info.Type,
 					position: Number(info.PosNbr),

--- a/server/src/spec.ts
+++ b/server/src/spec.ts
@@ -39,19 +39,19 @@ export function getPrettyDocs(docs: any): CommandDoc {
 			paramaters.map((parm: any) => {
 				const info = parm[`$`];
 				const qual = parm.Qual;
-				const spcVal = parm.SpcVal;
+				const elem = parm.Elem ? [...parm.Elem].flatMap(item => item.SpcVal || []) : [];
+				const val = [...(parm.SpcVal || []), ...(parm.SngVal || []), ...(parm.ChoicePgmValues || []), ...(elem || [])].flatMap(item => item.Value);
 
 				let specialValues = [];
 
-				if (spcVal && spcVal.length > 0) {
-					const opts = spcVal[0].Value;
-
-					specialValues = opts.map((value: any) => value[`$`].Val);
+				if (val && val.length > 0) {
+					specialValues = val.map((value: any) => value[`$`].Val);
 				}
 
 				return {
 					keyword: info.Kwd,
 					prompt: info.Prompt,
+
 					choice: info.Choice,
 					type: info.Type,
 					position: Number(info.PosNbr),


### PR DESCRIPTION
Issue:

ENDTCPSVR SERVER() is not showing any suggestions for SERVER.

Fix: 
Earlier we used to only capture the SpcVal from the command data and now with the new fix we are capturing all the below values and is giving suggestions for all the Parameters.
1. SngVal
2. ChoicePgmValues
3. SpcVal
4. Elem.SpcVal

<img width="782" height="371" alt="image" src="https://github.com/user-attachments/assets/0265b415-7bee-4166-b4ef-33cfa1f44437" />
