### PR TITLE
Add hover support for CL commands and parameters

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"jsdom": "^26.1.0",
 				"node-html-markdown": "^1.3.0",
-				"vscode-languageclient": "5.1.1",
+				"vscode-languageclient": "^7.0.0",
 				"xml2js": "^0.6.2"
 			},
 			"devDependencies": {
@@ -286,8 +286,7 @@
 		"node_modules/balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"node_modules/big-integer": {
 			"version": "1.6.48",
@@ -327,7 +326,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -366,8 +364,7 @@
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"node_modules/core-util-is": {
 			"version": "1.0.2",
@@ -729,7 +726,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -909,11 +905,15 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"license": "ISC",
 			"bin": {
-				"semver": "bin/semver"
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/setimmediate": {
@@ -1013,38 +1013,43 @@
 			"dev": true
 		},
 		"node_modules/vscode-jsonrpc": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-			"integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+			"integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.0.0 || >=10.0.0"
 			}
 		},
 		"node_modules/vscode-languageclient": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.1.1.tgz",
-			"integrity": "sha512-jMxshi+BPRQFNG8GB00dJv7ldqMda0be26laYYll/udtJuHbog6RqK10GSxHWDN0PgY0b0m5fePyTk3bq8a0TA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
+			"integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+			"license": "MIT",
 			"dependencies": {
-				"semver": "^5.5.0",
-				"vscode-languageserver-protocol": "3.13.0"
+				"minimatch": "^3.0.4",
+				"semver": "^7.3.4",
+				"vscode-languageserver-protocol": "3.16.0"
 			},
 			"engines": {
-				"vscode": "^1.26"
+				"vscode": "^1.52.0"
 			}
 		},
 		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.13.0.tgz",
-			"integrity": "sha512-2ZGKwI+P2ovQll2PGAp+2UfJH+FK9eait86VBUdkPd9HRlm8e58aYT9pV/NYanHOcp3pL6x2yTLVCFMcTer0mg==",
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+			"integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+			"license": "MIT",
 			"dependencies": {
-				"vscode-jsonrpc": "^4.0.0",
-				"vscode-languageserver-types": "3.13.0"
+				"vscode-jsonrpc": "6.0.0",
+				"vscode-languageserver-types": "3.16.0"
 			}
 		},
 		"node_modules/vscode-languageserver-types": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.13.0.tgz",
-			"integrity": "sha512-BnJIxS+5+8UWiNKCP7W3g9FlE7fErFw0ofP5BXJe7c2tl0VeWh+nNHFbwAS2vmVC4a5kYxHBjRy0UeOtziemVA=="
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+			"integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==",
+			"license": "MIT"
 		},
 		"node_modules/w3c-xmlserializer": {
 			"version": "5.0.0",
@@ -1320,8 +1325,7 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"big-integer": {
 			"version": "1.6.48",
@@ -1354,7 +1358,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -1384,8 +1387,7 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -1641,7 +1643,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -1784,9 +1785,9 @@
 			}
 		},
 		"semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="
 		},
 		"setimmediate": {
 			"version": "1.0.5",
@@ -1868,32 +1869,33 @@
 			"dev": true
 		},
 		"vscode-jsonrpc": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-			"integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+			"integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
 		},
 		"vscode-languageclient": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.1.1.tgz",
-			"integrity": "sha512-jMxshi+BPRQFNG8GB00dJv7ldqMda0be26laYYll/udtJuHbog6RqK10GSxHWDN0PgY0b0m5fePyTk3bq8a0TA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
+			"integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
 			"requires": {
-				"semver": "^5.5.0",
-				"vscode-languageserver-protocol": "3.13.0"
+				"minimatch": "^3.0.4",
+				"semver": "^7.3.4",
+				"vscode-languageserver-protocol": "3.16.0"
 			}
 		},
 		"vscode-languageserver-protocol": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.13.0.tgz",
-			"integrity": "sha512-2ZGKwI+P2ovQll2PGAp+2UfJH+FK9eait86VBUdkPd9HRlm8e58aYT9pV/NYanHOcp3pL6x2yTLVCFMcTer0mg==",
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+			"integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
 			"requires": {
-				"vscode-jsonrpc": "^4.0.0",
-				"vscode-languageserver-types": "3.13.0"
+				"vscode-jsonrpc": "6.0.0",
+				"vscode-languageserver-types": "3.16.0"
 			}
 		},
 		"vscode-languageserver-types": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.13.0.tgz",
-			"integrity": "sha512-BnJIxS+5+8UWiNKCP7W3g9FlE7fErFw0ofP5BXJe7c2tl0VeWh+nNHFbwAS2vmVC4a5kYxHBjRy0UeOtziemVA=="
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+			"integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
 		},
 		"w3c-xmlserializer": {
 			"version": "5.0.0",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,11 +9,14 @@
 			"version": "0.0.1",
 			"license": "MIT",
 			"dependencies": {
+				"jsdom": "^26.1.0",
+				"node-html-markdown": "^1.3.0",
 				"vscode-languageclient": "5.1.1",
 				"xml2js": "^0.6.2"
 			},
 			"devDependencies": {
 				"@halcyontech/vscode-ibmi-types": "^2.17.0",
+				"@types/jsdom": "^27.0.0",
 				"@types/node": "^18.11.5",
 				"@types/vscode": "^1.50.0",
 				"@types/xml2js": "^0.4.11",
@@ -21,6 +24,129 @@
 			},
 			"engines": {
 				"vscode": "^1.50.0"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+			"integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/css-calc": "^2.1.3",
+				"@csstools/css-color-parser": "^3.0.9",
+				"@csstools/css-parser-algorithms": "^3.0.4",
+				"@csstools/css-tokenizer": "^3.0.3",
+				"lru-cache": "^10.4.3"
+			}
+		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+			"integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+			"integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/color-helpers": "^5.1.0",
+				"@csstools/css-calc": "^2.1.4"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@halcyontech/vscode-ibmi-types": {
@@ -39,11 +165,30 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/@types/jsdom": {
+			"version": "27.0.0",
+			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-27.0.0.tgz",
+			"integrity": "sha512-NZyFl/PViwKzdEkQg96gtnB8wm+1ljhdDay9ahn4hgb+SfVtPCbm3TlmDUFXTA+MGN3CijicnMhG18SI5H3rFw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/tough-cookie": "*",
+				"parse5": "^7.0.0"
+			}
+		},
 		"node_modules/@types/node": {
 			"version": "18.11.5",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.5.tgz",
 			"integrity": "sha512-3JRwhbjI+cHLAkUorhf8RnqUbFXajvzX4q6fMn5JwkgtuwfYtRQYI3u4V92vI6NJuTsbBQWWh3RZjFsuevyMGQ==",
 			"dev": true
+		},
+		"node_modules/@types/tough-cookie": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/vscode": {
 			"version": "1.64.0",
@@ -87,23 +232,6 @@
 				"node": ">= 6.0.0"
 			}
 		},
-		"node_modules/@vscode/test-electron/node_modules/debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@vscode/test-electron/node_modules/http-proxy-agent": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -131,12 +259,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/@vscode/test-electron/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
-		},
 		"node_modules/@vscode/test-electron/node_modules/rimraf": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -150,6 +272,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -185,6 +316,12 @@
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
 			"integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
 			"dev": true
+		},
+		"node_modules/boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+			"license": "ISC"
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -238,6 +375,150 @@
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 			"dev": true
 		},
+		"node_modules/css-select": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+			"integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boolbase": "^1.0.0",
+				"css-what": "^6.1.0",
+				"domhandler": "^5.0.2",
+				"domutils": "^3.0.1",
+				"nth-check": "^2.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/css-what": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+			"integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/cssstyle": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+			"integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/css-color": "^3.2.0",
+				"rrweb-cssom": "^0.8.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/data-urls": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"license": "MIT"
+		},
+		"node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/dom-serializer/node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/domutils": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+			"integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
 		"node_modules/duplexer2": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -245,6 +526,18 @@
 			"dev": true,
 			"dependencies": {
 				"readable-stream": "^2.0.2"
+			}
+		},
+		"node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -294,6 +587,65 @@
 			"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
 			"dev": true
 		},
+		"node_modules/he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"license": "MIT",
+			"bin": {
+				"he": "bin/he"
+			}
+		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-encoding": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -310,17 +662,68 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"license": "MIT"
+		},
 		"node_modules/isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 			"dev": true
 		},
+		"node_modules/jsdom": {
+			"version": "26.1.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+			"license": "MIT",
+			"dependencies": {
+				"cssstyle": "^4.2.1",
+				"data-urls": "^5.0.0",
+				"decimal.js": "^10.5.0",
+				"html-encoding-sniffer": "^4.0.0",
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.6",
+				"is-potential-custom-element-name": "^1.0.1",
+				"nwsapi": "^2.2.16",
+				"parse5": "^7.2.1",
+				"rrweb-cssom": "^0.8.0",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^5.1.1",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^7.0.0",
+				"whatwg-encoding": "^3.1.1",
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.1.1",
+				"ws": "^8.18.0",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/listenercount": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
 			"integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
 			"dev": true
+		},
+		"node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"license": "ISC"
 		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
@@ -352,6 +755,52 @@
 				"mkdirp": "bin/cmd.js"
 			}
 		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/node-html-markdown": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/node-html-markdown/-/node-html-markdown-1.3.0.tgz",
+			"integrity": "sha512-OeFi3QwC/cPjvVKZ114tzzu+YoR+v9UXW5RwSXGUqGb0qCl0DvP406tzdL7SFn8pZrMyzXoisfG2zcuF9+zw4g==",
+			"license": "MIT",
+			"dependencies": {
+				"node-html-parser": "^6.1.1"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/node-html-parser": {
+			"version": "6.1.13",
+			"resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
+			"integrity": "sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==",
+			"license": "MIT",
+			"dependencies": {
+				"css-select": "^5.1.0",
+				"he": "1.2.0"
+			}
+		},
+		"node_modules/nth-check": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boolbase": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/nth-check?sponsor=1"
+			}
+		},
+		"node_modules/nwsapi": {
+			"version": "2.2.23",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+			"integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+			"license": "MIT"
+		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -359,6 +808,18 @@
 			"dev": true,
 			"dependencies": {
 				"wrappy": "1"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
 		"node_modules/path-is-absolute": {
@@ -375,6 +836,15 @@
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
+		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/readable-stream": {
 			"version": "2.3.7",
@@ -403,16 +873,40 @@
 				"rimraf": "bin.js"
 			}
 		},
+		"node_modules/rrweb-cssom": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+			"integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+			"license": "MIT"
+		},
 		"node_modules/safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true
 		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT"
+		},
 		"node_modules/sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"license": "ISC",
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
+			}
 		},
 		"node_modules/semver": {
 			"version": "5.7.2",
@@ -435,6 +929,54 @@
 			"dev": true,
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
+			}
+		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"license": "MIT"
+		},
+		"node_modules/tldts": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+			"integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^6.1.86"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+			"integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+			"license": "MIT"
+		},
+		"node_modules/tough-cookie": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+			"integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tldts": "^6.1.32"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/traverse": {
@@ -504,11 +1046,97 @@
 			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.13.0.tgz",
 			"integrity": "sha512-BnJIxS+5+8UWiNKCP7W3g9FlE7fErFw0ofP5BXJe7c2tl0VeWh+nNHFbwAS2vmVC4a5kYxHBjRy0UeOtziemVA=="
 		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"license": "MIT",
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/whatwg-encoding": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+			"deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+			"license": "MIT",
+			"dependencies": {
+				"iconv-lite": "0.6.3"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+			"license": "MIT",
+			"dependencies": {
+				"tr46": "^5.1.0",
+				"webidl-conversions": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
+		},
+		"node_modules/ws": {
+			"version": "8.19.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/xml2js": {
 			"version": "0.6.2",
@@ -529,9 +1157,58 @@
 			"engines": {
 				"node": ">=4.0"
 			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"license": "MIT"
 		}
 	},
 	"dependencies": {
+		"@asamuzakjp/css-color": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+			"integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+			"requires": {
+				"@csstools/css-calc": "^2.1.3",
+				"@csstools/css-color-parser": "^3.0.9",
+				"@csstools/css-parser-algorithms": "^3.0.4",
+				"@csstools/css-tokenizer": "^3.0.3",
+				"lru-cache": "^10.4.3"
+			}
+		},
+		"@csstools/color-helpers": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+			"integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="
+		},
+		"@csstools/css-calc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+			"requires": {}
+		},
+		"@csstools/css-color-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+			"integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+			"requires": {
+				"@csstools/color-helpers": "^5.1.0",
+				"@csstools/css-calc": "^2.1.4"
+			}
+		},
+		"@csstools/css-parser-algorithms": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+			"requires": {}
+		},
+		"@csstools/css-tokenizer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="
+		},
 		"@halcyontech/vscode-ibmi-types": {
 			"version": "2.17.2",
 			"resolved": "https://registry.npmjs.org/@halcyontech/vscode-ibmi-types/-/vscode-ibmi-types-2.17.2.tgz",
@@ -544,10 +1221,27 @@
 			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
 			"dev": true
 		},
+		"@types/jsdom": {
+			"version": "27.0.0",
+			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-27.0.0.tgz",
+			"integrity": "sha512-NZyFl/PViwKzdEkQg96gtnB8wm+1ljhdDay9ahn4hgb+SfVtPCbm3TlmDUFXTA+MGN3CijicnMhG18SI5H3rFw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"@types/tough-cookie": "*",
+				"parse5": "^7.0.0"
+			}
+		},
 		"@types/node": {
 			"version": "18.11.5",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.5.tgz",
 			"integrity": "sha512-3JRwhbjI+cHLAkUorhf8RnqUbFXajvzX4q6fMn5JwkgtuwfYtRQYI3u4V92vI6NJuTsbBQWWh3RZjFsuevyMGQ==",
+			"dev": true
+		},
+		"@types/tough-cookie": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
 			"dev": true
 		},
 		"@types/vscode": {
@@ -586,15 +1280,6 @@
 						"debug": "4"
 					}
 				},
-				"debug": {
-					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
 				"http-proxy-agent": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -616,12 +1301,6 @@
 						"debug": "4"
 					}
 				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				},
 				"rimraf": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -632,6 +1311,11 @@
 					}
 				}
 			}
+		},
+		"agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -660,6 +1344,11 @@
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
 			"integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
 			"dev": true
+		},
+		"boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -704,6 +1393,94 @@
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 			"dev": true
 		},
+		"css-select": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+			"integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+			"requires": {
+				"boolbase": "^1.0.0",
+				"css-what": "^6.1.0",
+				"domhandler": "^5.0.2",
+				"domutils": "^3.0.1",
+				"nth-check": "^2.0.1"
+			}
+		},
+		"css-what": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+			"integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="
+		},
+		"cssstyle": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+			"integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+			"requires": {
+				"@asamuzakjp/css-color": "^3.2.0",
+				"rrweb-cssom": "^0.8.0"
+			}
+		},
+		"data-urls": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+			"requires": {
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0"
+			}
+		},
+		"debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"requires": {
+				"ms": "^2.1.3"
+			}
+		},
+		"decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="
+		},
+		"dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"requires": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"dependencies": {
+				"entities": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+					"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+				}
+			}
+		},
+		"domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+		},
+		"domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"requires": {
+				"domelementtype": "^2.3.0"
+			}
+		},
+		"domutils": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+			"integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+			"requires": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			}
+		},
 		"duplexer2": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -712,6 +1489,11 @@
 			"requires": {
 				"readable-stream": "^2.0.2"
 			}
+		},
+		"entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -751,6 +1533,45 @@
 			"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
 			"dev": true
 		},
+		"he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+		},
+		"html-encoding-sniffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+			"requires": {
+				"whatwg-encoding": "^3.1.1"
+			}
+		},
+		"http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"requires": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			}
+		},
+		"https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"requires": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			}
+		},
+		"iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			}
+		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -767,17 +1588,54 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
+		"is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 			"dev": true
 		},
+		"jsdom": {
+			"version": "26.1.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+			"requires": {
+				"cssstyle": "^4.2.1",
+				"data-urls": "^5.0.0",
+				"decimal.js": "^10.5.0",
+				"html-encoding-sniffer": "^4.0.0",
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.6",
+				"is-potential-custom-element-name": "^1.0.1",
+				"nwsapi": "^2.2.16",
+				"parse5": "^7.2.1",
+				"rrweb-cssom": "^0.8.0",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^5.1.1",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^7.0.0",
+				"whatwg-encoding": "^3.1.1",
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.1.1",
+				"ws": "^8.18.0",
+				"xml-name-validator": "^5.0.0"
+			}
+		},
 		"listenercount": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
 			"integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
 			"dev": true
+		},
+		"lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
 		},
 		"minimatch": {
 			"version": "3.1.2",
@@ -803,6 +1661,41 @@
 				"minimist": "^1.2.5"
 			}
 		},
+		"ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+		},
+		"node-html-markdown": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/node-html-markdown/-/node-html-markdown-1.3.0.tgz",
+			"integrity": "sha512-OeFi3QwC/cPjvVKZ114tzzu+YoR+v9UXW5RwSXGUqGb0qCl0DvP406tzdL7SFn8pZrMyzXoisfG2zcuF9+zw4g==",
+			"requires": {
+				"node-html-parser": "^6.1.1"
+			}
+		},
+		"node-html-parser": {
+			"version": "6.1.13",
+			"resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
+			"integrity": "sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==",
+			"requires": {
+				"css-select": "^5.1.0",
+				"he": "1.2.0"
+			}
+		},
+		"nth-check": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+			"requires": {
+				"boolbase": "^1.0.0"
+			}
+		},
+		"nwsapi": {
+			"version": "2.2.23",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+			"integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ=="
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -810,6 +1703,14 @@
 			"dev": true,
 			"requires": {
 				"wrappy": "1"
+			}
+		},
+		"parse5": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"requires": {
+				"entities": "^6.0.0"
 			}
 		},
 		"path-is-absolute": {
@@ -823,6 +1724,11 @@
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
+		},
+		"punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
 		},
 		"readable-stream": {
 			"version": "2.3.7",
@@ -848,16 +1754,34 @@
 				"glob": "^7.1.3"
 			}
 		},
+		"rrweb-cssom": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+			"integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="
+		},
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true
 		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+		},
+		"saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"requires": {
+				"xmlchars": "^2.2.0"
+			}
 		},
 		"semver": {
 			"version": "5.7.2",
@@ -877,6 +1801,40 @@
 			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
+			}
+		},
+		"symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+		},
+		"tldts": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+			"integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+			"requires": {
+				"tldts-core": "^6.1.86"
+			}
+		},
+		"tldts-core": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+			"integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="
+		},
+		"tough-cookie": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+			"integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+			"requires": {
+				"tldts": "^6.1.32"
+			}
+		},
+		"tr46": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+			"requires": {
+				"punycode": "^2.3.1"
 			}
 		},
 		"traverse": {
@@ -937,11 +1895,57 @@
 			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.13.0.tgz",
 			"integrity": "sha512-BnJIxS+5+8UWiNKCP7W3g9FlE7fErFw0ofP5BXJe7c2tl0VeWh+nNHFbwAS2vmVC4a5kYxHBjRy0UeOtziemVA=="
 		},
+		"w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"requires": {
+				"xml-name-validator": "^5.0.0"
+			}
+		},
+		"webidl-conversions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+		},
+		"whatwg-encoding": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+			"requires": {
+				"iconv-lite": "0.6.3"
+			}
+		},
+		"whatwg-mimetype": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="
+		},
+		"whatwg-url": {
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+			"requires": {
+				"tr46": "^5.1.0",
+				"webidl-conversions": "^7.0.0"
+			}
+		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
+		},
+		"ws": {
+			"version": "8.19.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+			"requires": {}
+		},
+		"xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="
 		},
 		"xml2js": {
 			"version": "0.6.2",
@@ -956,6 +1960,11 @@
 			"version": "11.0.1",
 			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
 			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+		},
+		"xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
 		}
 	}
 }

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
 	"dependencies": {
 		"jsdom": "^26.1.0",
 		"node-html-markdown": "^1.3.0",
-		"vscode-languageclient": "5.1.1",
+		"vscode-languageclient": "^7.0.0",
 		"xml2js": "^0.6.2"
 	},
 	"devDependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -9,11 +9,14 @@
 		"vscode": "^1.50.0"
 	},
 	"dependencies": {
+		"jsdom": "^26.1.0",
+		"node-html-markdown": "^1.3.0",
 		"vscode-languageclient": "5.1.1",
 		"xml2js": "^0.6.2"
 	},
 	"devDependencies": {
-    	"@halcyontech/vscode-ibmi-types": "^2.17.0",
+		"@halcyontech/vscode-ibmi-types": "^2.17.0",
+		"@types/jsdom": "^27.0.0",
 		"@types/node": "^18.11.5",
 		"@types/vscode": "^1.50.0",
 		"@types/xml2js": "^0.4.11",

--- a/client/src/api/ibmi.ts
+++ b/client/src/api/ibmi.ts
@@ -1,6 +1,7 @@
 import { CodeForIBMi } from "@halcyontech/vscode-ibmi-types";
 import { ComponentRegistry } from '@halcyontech/vscode-ibmi-types/api/components/manager';
 import { VscodeTools } from "@halcyontech/vscode-ibmi-types/ui/Tools";
+import { CustomUI } from '@halcyontech/vscode-ibmi-types/webviews/CustomUI';
 import Instance from "@halcyontech/vscode-ibmi-types/Instance";
 import { Extension, extensions } from "vscode";
 
@@ -20,6 +21,10 @@ export function getInstance(): Instance | undefined {
 
 export function getComponentRegistry(): ComponentRegistry | undefined {
     return (baseExtension && baseExtension.isActive && baseExtension.exports ? baseExtension.exports.componentRegistry : undefined);
+}
+
+export function getCustomUI(): CustomUI | undefined {
+  return (baseExtension && baseExtension.isActive && baseExtension.exports ? baseExtension.exports.customUI() : undefined);
 }
 
 export function getVSCodeTools(): typeof VscodeTools | undefined {

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -1,8 +1,7 @@
 import { ExtensionContext, commands, Uri, window, ViewColumn } from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { getModules } from './requests';
-import { getCustomUI } from './api/ibmi';
-import { CLDoc, GenCmdDoc } from './gencmddoc';
+import { GenCmdDoc } from './gencmddoc';
 
 export function registerCommands(context: ExtensionContext, client: LanguageClient) {
   context.subscriptions.push(
@@ -11,12 +10,8 @@ export function registerCommands(context: ExtensionContext, client: LanguageClie
     }),
 
     commands.registerCommand(`vscode-clle.viewFullDocumentation`, async (object: string, library: string) => {
-      const clDoc = await GenCmdDoc.getCLDoc(object, library);
-      if (clDoc) {
-        const panel = window.createWebviewPanel(`tab`, `${clDoc.doc.command.name} Documentation`, { viewColumn: ViewColumn.Active }, { enableScripts: true });
-        panel.webview.html = clDoc.html;
-        panel.reveal();
-      } else {
+      const isDocOpened = await GenCmdDoc.openClDoc(object, library);
+      if (!isDocOpened) {
         await window.showErrorMessage(`Documentation for ${object} command not found`);
       }
     })

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -2,7 +2,7 @@ import { ExtensionContext, commands, Uri, window, ViewColumn } from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { getModules } from './requests';
 import { getCustomUI } from './api/ibmi';
-import { CLDoc } from './gencmddoc';
+import { CLDoc, GenCmdDoc } from './gencmddoc';
 
 export function registerCommands(context: ExtensionContext, client: LanguageClient) {
   context.subscriptions.push(
@@ -11,7 +11,7 @@ export function registerCommands(context: ExtensionContext, client: LanguageClie
     }),
 
     commands.registerCommand(`vscode-clle.viewFullDocumentation`, async (object: string, library: string) => {
-      const clDoc = await client.sendRequest<{ html: string, doc: CLDoc } | undefined>(`getCLDoc`, [object, library]);
+      const clDoc = await GenCmdDoc.getCLDoc(object, library);
       if (clDoc) {
         const panel = window.createWebviewPanel(`tab`, `${clDoc.doc.command.name} Documentation`, { viewColumn: ViewColumn.Active }, { enableScripts: true });
         panel.webview.html = clDoc.html;

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -1,5 +1,5 @@
 import { ExtensionContext, commands, Uri } from 'vscode';
-import { LanguageClient } from 'vscode-languageclient';
+import { LanguageClient } from 'vscode-languageclient/node';
 import { getModules } from './requests';
 
 export function registerCommands(context: ExtensionContext, client: LanguageClient) {

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -6,6 +6,10 @@ export function registerCommands(context: ExtensionContext, client: LanguageClie
   context.subscriptions.push(
     commands.registerCommand(`vscode-clle.server.getModules`, async (uri: Uri, content: string) => {
       return await getModules(client, uri, content);
+    }),
+    
+    commands.registerCommand(`vscode-clle.viewFullDocumentation`, async (object: string, library: string) => {
+      return;
     })
   )
 }

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -1,15 +1,24 @@
-import { ExtensionContext, commands, Uri } from 'vscode';
+import { ExtensionContext, commands, Uri, window, ViewColumn } from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { getModules } from './requests';
+import { getCustomUI } from './api/ibmi';
+import { CLDoc } from './gencmddoc';
 
 export function registerCommands(context: ExtensionContext, client: LanguageClient) {
   context.subscriptions.push(
     commands.registerCommand(`vscode-clle.server.getModules`, async (uri: Uri, content: string) => {
       return await getModules(client, uri, content);
     }),
-    
+
     commands.registerCommand(`vscode-clle.viewFullDocumentation`, async (object: string, library: string) => {
-      return;
+      const clDoc = await client.sendRequest<{ html: string, doc: CLDoc } | undefined>(`getCLDoc`, [object, library]);
+      if (clDoc) {
+        const panel = window.createWebviewPanel(`tab`, `${clDoc.doc.command.name} Documentation`, { viewColumn: ViewColumn.Active }, { enableScripts: true });
+        panel.webview.html = clDoc.html;
+        panel.reveal();
+      } else {
+        await window.showErrorMessage(`Documentation for ${object} command not found`);
+      }
     })
   )
 }

--- a/client/src/components/gencmdxml/gencmdxml.ts
+++ b/client/src/components/gencmdxml/gencmdxml.ts
@@ -28,6 +28,9 @@ export default class GenCmdXml implements IBMiComponent {
 				return genCmdXmlComponent;
 			}
 		}
+
+		// TODO: When the component version is bumped to 2, replace the above code with:
+		// return connection?.getComponent<GenCmdXml>(GenCmdXml.ID);
 	}
 
 	async getRemoteState(connection: IBMi, installDirectory: string): Promise<ComponentState> {

--- a/client/src/components/gencmdxml/gencmdxml.ts
+++ b/client/src/components/gencmdxml/gencmdxml.ts
@@ -18,7 +18,16 @@ export default class GenCmdXml implements IBMiComponent {
 	static get(): GenCmdXml | undefined {
 		const instance = getInstance();
 		const connection = instance?.getConnection();
-		return connection?.getComponent<GenCmdXml>(GenCmdXml.ID);
+		const componentManager = connection.getComponentManager();
+		const componentStates = componentManager.getComponentStates();
+		const genCmdXmlComponentState = componentStates.find(cs => cs.id.name === GenCmdXml.ID);
+		if (genCmdXmlComponentState.state === `Installed` || genCmdXmlComponentState.state === `NeedsUpdate`) {
+			const allAvailableComponents = componentManager.getAllAvailableComponents();
+			const genCmdXmlComponent = allAvailableComponents.find(ac => ac.getIdentification().name === GenCmdXml.ID) as GenCmdXml;
+			if (genCmdXmlComponent) {
+				return genCmdXmlComponent;
+			}
+		}
 	}
 
 	async getRemoteState(connection: IBMi, installDirectory: string): Promise<ComponentState> {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -9,9 +9,13 @@ import { registerCommands } from './commands';
 import GenCmdXml from './components/gencmdxml/gencmdxml';
 import { GenCmdDoc } from './gencmddoc';
 
+export interface CLLE {
+	genCmdDoc: typeof GenCmdDoc
+}
+
 let client: LanguageClient;
 
-export function activate(context: ExtensionContext) {
+export function activate(context: ExtensionContext): CLLE {
 	loadBase();
 
 	// The server is implemented in node
@@ -96,6 +100,10 @@ export function activate(context: ExtensionContext) {
 	CLSyntaxChecker.registerComponent(context);
 	GenCmdXml.registerComponent(context);
 	ProblemProvider.registerProblemProvider(context);
+
+	return {
+		genCmdDoc: GenCmdDoc
+	}
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { ExtensionContext } from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient/node';
-import { getInstance, loadBase } from './api/ibmi';
+import { loadBase } from './api/ibmi';
 import { initialiseRunner } from './clRunner';
 import { CLSyntaxChecker } from './components/syntaxChecker/checker';
 import { ProblemProvider } from './components/syntaxChecker/problemProvider';

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,12 +1,13 @@
 import * as path from 'path';
 import { ExtensionContext } from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient';
-import { loadBase } from './api/ibmi';
+import { getInstance, loadBase } from './api/ibmi';
 import { initialiseRunner } from './clRunner';
 import { CLSyntaxChecker } from './components/syntaxChecker/checker';
 import { ProblemProvider } from './components/syntaxChecker/problemProvider';
 import { registerCommands } from './commands';
 import GenCmdXml from './components/gencmdxml/gencmdxml';
+import { GenCmdDoc } from './gencmddoc';
 
 let client: LanguageClient;
 
@@ -69,6 +70,17 @@ export function activate(context: ExtensionContext) {
 				const definition = await genCmdXml.getFileDefinition(qualifiedObject[0], qualifiedObject[1]);
 
 				return definition;
+			}
+		});
+
+		client.onRequest("getCLDoc", async (qualifiedObject: string[]) => {
+			try {
+				const html = await GenCmdDoc.generateHtml(qualifiedObject[0], qualifiedObject[1]);
+				if (html) {
+					return GenCmdDoc.parseHtml(qualifiedObject[0], html);
+				}
+			} catch (e) {
+				console.log(e);
 			}
 		});
 	});

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -80,7 +80,10 @@ export function activate(context: ExtensionContext) {
 			try {
 				const html = await GenCmdDoc.generateHtml(qualifiedObject[0], qualifiedObject[1]);
 				if (html) {
-					return GenCmdDoc.parseHtml(qualifiedObject[0], html);
+					const doc = GenCmdDoc.parseHtml(qualifiedObject[0], html);
+					if (doc) {
+						return { html, doc };
+					}
 				}
 			} catch (e) {
 				console.log(e);

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -10,7 +10,7 @@ import GenCmdXml from './components/gencmdxml/gencmdxml';
 import { GenCmdDoc } from './gencmddoc';
 
 export interface CLLE {
-	genCmdDoc: typeof GenCmdDoc
+	genCmdDoc: GenCmdDoc
 }
 
 let client: LanguageClient;
@@ -82,13 +82,7 @@ export function activate(context: ExtensionContext): CLLE {
 
 		client.onRequest("getCLDoc", async (qualifiedObject: string[]) => {
 			try {
-				const html = await GenCmdDoc.generateHtml(qualifiedObject[0], qualifiedObject[1]);
-				if (html) {
-					const doc = GenCmdDoc.parseHtml(qualifiedObject[0], html);
-					if (doc) {
-						return { html, doc };
-					}
-				}
+				return await GenCmdDoc.getCLDoc(qualifiedObject[0], qualifiedObject[1]);
 			} catch (e) {
 				console.log(e);
 			}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { ExtensionContext } from 'vscode';
-import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient';
+import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient/node';
 import { getInstance, loadBase } from './api/ibmi';
 import { initialiseRunner } from './clRunner';
 import { CLSyntaxChecker } from './components/syntaxChecker/checker';
@@ -37,6 +37,9 @@ export function activate(context: ExtensionContext) {
 	const clientOptions: LanguageClientOptions = {
 		// Register the server for plain text documents
 		documentSelector: [{ language: 'cl' }],
+		markdown: {
+			isTrusted: true
+		}
 		// synchronize: {
 		// 	// Notify the server about file changes to '.clientrc files contained in the workspace
 		// 	fileEvents: workspace.createFileSystemWatcher('**/.clientrc')

--- a/client/src/gencmddoc.ts
+++ b/client/src/gencmddoc.ts
@@ -70,7 +70,7 @@ export class GenCmdDoc {
 			});
 
 			if (generateResult.code === 0) {
-				const html = (await content.downloadStreamfileRaw(`/tmp/${toStmf}`)).toString();
+				const html = (await content.downloadStreamfileRaw(`${toDir}/${toStmf}`)).toString();
 				return html;
 			}
 		}

--- a/client/src/gencmddoc.ts
+++ b/client/src/gencmddoc.ts
@@ -23,13 +23,14 @@ export namespace GenCmdDoc {
 		const instance = getInstance();
 		const connection = instance.getConnection();
 		const content = connection.getContent();
+		const config = connection.getConfig();
 
 		if (connection) {
 			const cmd = `${library}/${object}`;
 			const toStmf = `${library.replace('*', '')}_${object}`;
+			const toDir = config.tempDir;
 			const generateResult = await connection.runCommand({
-				command: `GENCMDDOC CMD(${cmd}) GENOPT(*HTML *SHOWCHOICEPGMVAL) REPLACE(*YES) TOSTMF('${toStmf}') TODIR('/tmp')`,
-				noLibList: true
+				command: `GENCMDDOC CMD(${cmd}) GENOPT(*HTML *SHOWCHOICEPGMVAL) REPLACE(*YES) TOSTMF('${toStmf}') TODIR('${toDir}')`
 			});
 
 			if (generateResult.code === 0) {

--- a/client/src/gencmddoc.ts
+++ b/client/src/gencmddoc.ts
@@ -2,7 +2,7 @@ import { getInstance } from './api/ibmi';
 import { NodeHtmlMarkdown } from "node-html-markdown";
 import { JSDOM } from "jsdom";
 
-interface DetailedCommandDoc {
+export interface CLDoc {
 	command: {
 		name: string;
 		description: string
@@ -34,7 +34,7 @@ export namespace GenCmdDoc {
 		}
 	}
 
-	export async function parseHtml(command: string, html: string): Promise<DetailedCommandDoc | undefined> {
+	export function parseHtml(command: string, html: string): CLDoc | undefined {
 		const dom = new JSDOM(html);
 		const doc = dom.window.document;
 
@@ -55,7 +55,7 @@ export namespace GenCmdDoc {
 		// Get parameter names
 		const h3 = doc.querySelector(`h3 > a[name="${command}.PARAMETERS.TABLE"]`).parentElement;
 		const table = h3.nextElementSibling;
-		const parameters: DetailedCommandDoc[`parameters`] = [];
+		const parameters: CLDoc[`parameters`] = [];
 		if (table) {
 			const rows = Array.from(table.querySelectorAll("tr")).slice(1);
 			rows.forEach(row => {

--- a/client/src/gencmddoc.ts
+++ b/client/src/gencmddoc.ts
@@ -28,7 +28,7 @@ export namespace GenCmdDoc {
 		if (connection) {
 			const cmd = `${library}/${object}`;
 			const toStmf = `${library.replace('*', '')}_${object}`;
-			const toDir = config.tempDir;
+			const toDir = `${config.tempDir}/gencmddoc`;
 			const generateResult = await connection.runCommand({
 				command: `GENCMDDOC CMD(${cmd}) GENOPT(*HTML *SHOWCHOICEPGMVAL) REPLACE(*YES) TOSTMF('${toStmf}') TODIR('${toDir}')`
 			});

--- a/client/src/gencmddoc.ts
+++ b/client/src/gencmddoc.ts
@@ -28,7 +28,7 @@ export namespace GenCmdDoc {
 		if (connection) {
 			const cmd = `${library}/${object}`;
 			const toStmf = `${library.replace('*', '')}_${object}`;
-			const toDir = `${config.tempDir}/gencmddoc`;
+			const toDir = config.tempDir;
 			const generateResult = await connection.runCommand({
 				command: `GENCMDDOC CMD(${cmd}) GENOPT(*HTML *SHOWCHOICEPGMVAL) REPLACE(*YES) TOSTMF('${toStmf}') TODIR('${toDir}')`
 			});

--- a/client/src/gencmddoc.ts
+++ b/client/src/gencmddoc.ts
@@ -1,4 +1,5 @@
 import { getInstance } from './api/ibmi';
+import { window, ViewColumn } from 'vscode';
 import { NodeHtmlMarkdown } from "node-html-markdown";
 import { JSDOM } from "jsdom";
 
@@ -20,6 +21,18 @@ export interface CLDoc {
 
 export class GenCmdDoc {
 	private static cachedClDocs: { [qualifiedObject: string]: { html: string, doc: CLDoc } | undefined } = {};
+
+	public static async openClDoc(object: string, library = '*LIBL'): Promise<boolean> {
+		const clDoc = await GenCmdDoc.getCLDoc(object, library);
+		if (clDoc) {
+			const panel = window.createWebviewPanel(`tab`, `${clDoc.doc.command.name} Documentation`, { viewColumn: ViewColumn.Active }, { enableScripts: true });
+			panel.webview.html = clDoc.html;
+			panel.reveal();
+			return true;
+		} else {
+			return false;
+		}
+	}
 
 	public static async getCLDoc(object: string, library = '*LIBL'): Promise<{ html: string, doc: CLDoc } | undefined> {
 		const validObject = object.toUpperCase();

--- a/client/src/gencmddoc.ts
+++ b/client/src/gencmddoc.ts
@@ -1,0 +1,88 @@
+import { getInstance } from './api/ibmi';
+import { NodeHtmlMarkdown } from "node-html-markdown";
+import { JSDOM } from "jsdom";
+
+interface DetailedCommandDoc {
+	command: {
+		name: string;
+		description: string
+	}
+	parameters: {
+		name: string;
+		description: string;
+	}[];
+}
+
+export namespace GenCmdDoc {
+	export async function generateHtml(object: string, library: string): Promise<string | undefined> {
+		const instance = getInstance();
+		const connection = instance.getConnection();
+		const content = connection.getContent();
+
+		if (connection) {
+			const cmd = `${library}/${object}`;
+			const toStmf = `${library.replace('*', '')}_${object}`;
+			const generateResult = await connection.runCommand({
+				command: `GENCMDDOC CMD(${cmd}) GENOPT(*HTML *SHOWCHOICEPGMVAL) REPLACE(*YES) TOSTMF('${toStmf}') TODIR('/tmp')`,
+				noLibList: true
+			});
+
+			if (generateResult.code === 0) {
+				const html = (await content.downloadStreamfileRaw(`/tmp/${toStmf}`)).toString();
+				return html;
+			}
+		}
+	}
+
+	export async function parseHtml(command: string, html: string): Promise<DetailedCommandDoc | undefined> {
+		const dom = new JSDOM(html);
+		const doc = dom.window.document;
+
+		// Get command name
+		const h2 = doc.querySelector(`h2`);
+		const commandName = h2?.textContent;
+		if (!commandName) {
+			return;
+		}
+
+		// Get command description
+		const tdInfo = doc.querySelector('td[valign="top"][align="left"]');
+		const tdHtml = tdInfo?.innerHTML ?? "";
+		const div = doc.querySelector(`div > a[name="${command}"]`)?.parentElement;
+		const divHtml = div?.innerHTML ?? "";
+		const commandDescription = NodeHtmlMarkdown.translate(`${tdHtml}\n\n${divHtml}`);
+
+		// Get parameter names
+		const h3 = doc.querySelector(`h3 > a[name="${command}.PARAMETERS.TABLE"]`).parentElement;
+		const table = h3.nextElementSibling;
+		const parameters: DetailedCommandDoc[`parameters`] = [];
+		if (table) {
+			const rows = Array.from(table.querySelectorAll("tr")).slice(1);
+			rows.forEach(row => {
+				const cells = row.querySelectorAll("td");
+				const parameterName = cells[0]?.textContent?.trim() ?? "";
+				if (parameterName) {
+					parameters.push({
+						name: parameterName,
+						description: ``
+					});
+				}
+			});
+		}
+
+		// Get parameter descriptions
+		parameters.forEach(param => {
+			const div = doc.querySelector(`div > a[name="${command}.${param.name}"]`)?.parentElement;
+			const divHtml = div?.innerHTML ?? "";
+			param.description = NodeHtmlMarkdown.translate(divHtml);
+		});
+
+		return {
+			command: {
+				name: commandName,
+				description: commandDescription
+			},
+			parameters
+		};
+	}
+}

--- a/client/src/requests.ts
+++ b/client/src/requests.ts
@@ -1,5 +1,5 @@
 import { Uri } from 'vscode';
-import { LanguageClient } from 'vscode-languageclient';
+import { LanguageClient } from 'vscode-languageclient/node';
 
 export async function getModules(client: LanguageClient, uri: Uri, content: string): Promise<any> {
 	return await client.sendRequest(`getModules`, [uri.toString(), content]);

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const webpack = require(`webpack`);
 const withDefaults = require(`../shared.webpack.config`);
 const path = require(`path`);
 
@@ -11,5 +12,8 @@ module.exports = withDefaults({
   output: {
     filename: `extension.js`,
     path: path.join(__dirname, `..`, `out`)
-  }
+  },
+  plugins: [
+    new webpack.IgnorePlugin({ resourceRegExp: /(canvas|bufferutil|utf-8-validate)/u })
+  ]
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.1.8",
 			"hasInstallScript": true,
 			"dependencies": {
-				"vscode-languageclient": "^5.1.1"
+				"vscode-languageclient": "^7.0.0"
 			},
 			"devDependencies": {
 				"@halcyontech/vscode-ibmi-types": "^2.16.3",
@@ -824,8 +824,7 @@
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
@@ -840,7 +839,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -1065,8 +1063,7 @@
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
@@ -2121,7 +2118,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
 			"dependencies": {
 				"yallist": "^4.0.0"
 			},
@@ -2194,7 +2190,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -2776,7 +2771,6 @@
 			"version": "7.5.4",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
 			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -3141,46 +3135,43 @@
 			}
 		},
 		"node_modules/vscode-jsonrpc": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-			"integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+			"integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.0.0 || >=10.0.0"
 			}
 		},
 		"node_modules/vscode-languageclient": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.1.1.tgz",
-			"integrity": "sha512-jMxshi+BPRQFNG8GB00dJv7ldqMda0be26laYYll/udtJuHbog6RqK10GSxHWDN0PgY0b0m5fePyTk3bq8a0TA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
+			"integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+			"license": "MIT",
 			"dependencies": {
-				"semver": "^5.5.0",
-				"vscode-languageserver-protocol": "3.13.0"
+				"minimatch": "^3.0.4",
+				"semver": "^7.3.4",
+				"vscode-languageserver-protocol": "3.16.0"
 			},
 			"engines": {
-				"vscode": "^1.26"
-			}
-		},
-		"node_modules/vscode-languageclient/node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"bin": {
-				"semver": "bin/semver"
+				"vscode": "^1.52.0"
 			}
 		},
 		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.13.0.tgz",
-			"integrity": "sha512-2ZGKwI+P2ovQll2PGAp+2UfJH+FK9eait86VBUdkPd9HRlm8e58aYT9pV/NYanHOcp3pL6x2yTLVCFMcTer0mg==",
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+			"integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+			"license": "MIT",
 			"dependencies": {
-				"vscode-jsonrpc": "^4.0.0",
-				"vscode-languageserver-types": "3.13.0"
+				"vscode-jsonrpc": "6.0.0",
+				"vscode-languageserver-types": "3.16.0"
 			}
 		},
 		"node_modules/vscode-languageserver-types": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.13.0.tgz",
-			"integrity": "sha512-BnJIxS+5+8UWiNKCP7W3g9FlE7fErFw0ofP5BXJe7c2tl0VeWh+nNHFbwAS2vmVC4a5kYxHBjRy0UeOtziemVA=="
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+			"integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==",
+			"license": "MIT"
 		},
 		"node_modules/watchpack": {
 			"version": "2.4.2",
@@ -3388,8 +3379,7 @@
 		"node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"node_modules/yargs": {
 			"version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,6 @@
 		"webpack-cli": "^5.1.4"
 	},
 	"dependencies": {
-		"vscode-languageclient": "^5.1.1"
+		"vscode-languageclient": "^7.0.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 			{
 				"command": "vscode-clle.runSelected",
 				"title": "Run selected CL command",
-				"category": "IBM i"
+				"category": "CLLE"
 			},
 			{
 				"command": "vscode-clle.syntax.checkDocument",
@@ -48,6 +48,11 @@
 				"category": "CLLE",
 				"enablement": "code-for-ibmi:connected == true && vscode-clle.syntax.checkerAvailable == true && vscode-clle.syntax.checkerRunning != true",
 				"icon": "$(check-all)"
+			},
+			{
+				"command": "vscode-clle.viewFullDocumentation",
+				"title": "View Full Documentation",
+				"category": "CLLE"
 			}
 		],
 		"keybindings": [
@@ -63,6 +68,10 @@
 				{
 					"command": "vscode-clle.runSelected",
 					"when": "code-for-ibmi:connected && editorLangId === cl"
+				},
+				{
+					"command": "vscode-clle.viewFullDocumentation",
+					"when": "never"
 				}
 			],
 			"editor/title": [

--- a/readme.md
+++ b/readme.md
@@ -6,9 +6,9 @@
 This extension adds language features for CL into the IDE, including:
 
 * Outline view
-* Content assist / Completion provider
+* Content assist / completion provider
 * Go to or peek definition and references
-* Content assist for CL commands
+* Content assist and hover support for CL commands
    * requires connection to IBM i through Code for IBM i or Merlin IDE.
 
 ## Developers

--- a/server/src/data.ts
+++ b/server/src/data.ts
@@ -1,13 +1,14 @@
 import { Module } from 'language';
-import { getCLDefinition, getFileDefinition } from './instance';
-import { Files, CommandDoc, getPrettyDocs } from './spec';
+import { getCLDefinition, getCLDoc, getFileDefinition } from './instance';
+import { Files, CommandDoc, getPrettyDocs, DetailedCommandDoc } from './spec';
 
-export const CLModules: {[uri: string]: Module} = {}
+export const CLModules: { [uri: string]: Module } = {}
 
-export const CLCommands: {[qualifiedObject: string]: CommandDoc|undefined} = {};
-export const FileDefinitions: {[qualifiedObject: string]: Files.ColumnDescription[]|undefined} = {};
+export const CLCommands: { [qualifiedObject: string]: CommandDoc | undefined } = {};
+export const FileDefinitions: { [qualifiedObject: string]: Files.ColumnDescription[] | undefined } = {};
+export const ClDocs: { [qualifiedObject: string]: DetailedCommandDoc | undefined } = {};
 
-export async function getCLspec(object: string, library = '*LIBL'): Promise<CommandDoc|undefined> {
+export async function getCLspec(object: string, library = '*LIBL'): Promise<CommandDoc | undefined> {
 	const validObject = object.toUpperCase();
 	const validLibrary = (library || `*LIBL`).toUpperCase();
 	const qualifiedPath = `${validObject}/${validLibrary}`;
@@ -21,7 +22,7 @@ export async function getCLspec(object: string, library = '*LIBL'): Promise<Comm
 	return CLCommands[qualifiedPath];
 }
 
-export function getFileSpecCache(object: string, library = '*LIBL', openId?: string): Files.ColumnDefinition[]|undefined {
+export function getFileSpecCache(object: string, library = '*LIBL', openId?: string): Files.ColumnDefinition[] | undefined {
 	const validObject = object.toUpperCase();
 	const validLibrary = (library || `*LIBL`).toUpperCase();
 	const qualifiedPath = `${validObject}/${validLibrary}`;
@@ -30,7 +31,7 @@ export function getFileSpecCache(object: string, library = '*LIBL', openId?: str
 	return (spec ? Files.getVariables(spec, openId) : undefined);
 }
 
-export async function getFileSpec(object: string, library = '*LIBL', openId?: string): Promise<Files.ColumnDefinition[]|undefined> {
+export async function getFileSpec(object: string, library = '*LIBL', openId?: string): Promise<Files.ColumnDefinition[] | undefined> {
 	const validObject = object.toUpperCase();
 	const validLibrary = (library || `*LIBL`).toUpperCase();
 	const qualifiedPath = `${validObject}/${validLibrary}`;
@@ -44,4 +45,20 @@ export async function getFileSpec(object: string, library = '*LIBL', openId?: st
 	FileDefinitions[qualifiedPath] = spec;
 
 	return (spec ? Files.getVariables(spec, openId) : undefined);
+}
+
+export async function getCLDocSpec(object: string, library = '*LIBL'): Promise<DetailedCommandDoc | undefined> {
+	const validObject = object.toUpperCase();
+	const validLibrary = (library || `*LIBL`).toUpperCase();
+	const qualifiedPath = `${validObject}/${validLibrary}`;
+
+	// Return from cache if it exists
+	if (ClDocs[qualifiedPath]) {
+		return ClDocs[qualifiedPath];
+	}
+
+	const doc = await getCLDoc(validObject, validLibrary);
+	ClDocs[qualifiedPath] = doc;
+
+	return ClDocs[qualifiedPath];
 }

--- a/server/src/data.ts
+++ b/server/src/data.ts
@@ -6,7 +6,6 @@ export const CLModules: { [uri: string]: Module } = {}
 
 export const CLCommands: { [qualifiedObject: string]: CommandDoc | undefined } = {};
 export const FileDefinitions: { [qualifiedObject: string]: Files.ColumnDescription[] | undefined } = {};
-export const ClDocs: { [qualifiedObject: string]: { html: string, doc: CLDoc } | undefined } = {};
 
 export async function getCLspec(object: string, library = '*LIBL'): Promise<CommandDoc | undefined> {
 	const validObject = object.toUpperCase();
@@ -50,15 +49,5 @@ export async function getFileSpec(object: string, library = '*LIBL', openId?: st
 export async function getCLDocSpec(object: string, library = '*LIBL'): Promise<{ html: string, doc: CLDoc } | undefined> {
 	const validObject = object.toUpperCase();
 	const validLibrary = (library || `*LIBL`).toUpperCase();
-	const qualifiedPath = `${validObject}/${validLibrary}`;
-
-	// Return from cache if it exists
-	if (ClDocs[qualifiedPath]) {
-		return ClDocs[qualifiedPath];
-	}
-
-	const doc = await getCLDoc(validObject, validLibrary);
-	ClDocs[qualifiedPath] = doc;
-
-	return ClDocs[qualifiedPath];
+	return await getCLDoc(validObject, validLibrary);
 }

--- a/server/src/data.ts
+++ b/server/src/data.ts
@@ -1,12 +1,12 @@
 import { Module } from 'language';
 import { getCLDefinition, getCLDoc, getFileDefinition } from './instance';
-import { Files, CommandDoc, getPrettyDocs, DetailedCommandDoc } from './spec';
+import { Files, CommandDoc, getPrettyDocs, CLDoc } from './spec';
 
 export const CLModules: { [uri: string]: Module } = {}
 
 export const CLCommands: { [qualifiedObject: string]: CommandDoc | undefined } = {};
 export const FileDefinitions: { [qualifiedObject: string]: Files.ColumnDescription[] | undefined } = {};
-export const ClDocs: { [qualifiedObject: string]: DetailedCommandDoc | undefined } = {};
+export const ClDocs: { [qualifiedObject: string]: { html: string, doc: CLDoc } | undefined } = {};
 
 export async function getCLspec(object: string, library = '*LIBL'): Promise<CommandDoc | undefined> {
 	const validObject = object.toUpperCase();
@@ -47,7 +47,7 @@ export async function getFileSpec(object: string, library = '*LIBL', openId?: st
 	return (spec ? Files.getVariables(spec, openId) : undefined);
 }
 
-export async function getCLDocSpec(object: string, library = '*LIBL'): Promise<DetailedCommandDoc | undefined> {
+export async function getCLDocSpec(object: string, library = '*LIBL'): Promise<{ html: string, doc: CLDoc } | undefined> {
 	const validObject = object.toUpperCase();
 	const validLibrary = (library || `*LIBL`).toUpperCase();
 	const qualifiedPath = `${validObject}/${validLibrary}`;

--- a/server/src/instance.ts
+++ b/server/src/instance.ts
@@ -7,11 +7,16 @@ import {
 import {
 	TextDocument
 } from 'vscode-languageserver-textdocument';
-import { DetailedCommandDoc, Files } from './spec';
+import { CLDoc, Files } from './spec';
+import { getCLDocSpec } from './data';
 
 // Create a connection for the server, using Node's IPC as a transport.
 // Also include all preview / proposed LSP features.
 export const connection = createConnection(ProposedFeatures.all);
+
+connection.onRequest("getCLDoc", async (qualifiedObject: string[]) => {
+	return await getCLDocSpec(qualifiedObject[0], qualifiedObject[1]);
+});
 
 // Create a simple text document manager.
 export const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);
@@ -24,6 +29,6 @@ export function getFileDefinition(object: string, library?: string): Promise<Fil
 	return connection.sendRequest("getFileDefinition", [object, library]);
 }
 
-export function getCLDoc(object: string, library?: string): Promise<DetailedCommandDoc | undefined> {
+export function getCLDoc(object: string, library?: string): Promise<{ html: string, doc: CLDoc } | undefined> {
 	return connection.sendRequest("getCLDoc", [object, library]);
 }

--- a/server/src/instance.ts
+++ b/server/src/instance.ts
@@ -7,7 +7,7 @@ import {
 import {
 	TextDocument
 } from 'vscode-languageserver-textdocument';
-import { Files } from './spec';
+import { DetailedCommandDoc, Files } from './spec';
 
 // Create a connection for the server, using Node's IPC as a transport.
 // Also include all preview / proposed LSP features.
@@ -16,10 +16,14 @@ export const connection = createConnection(ProposedFeatures.all);
 // Create a simple text document manager.
 export const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);
 
-export function getCLDefinition(object: string, library?: string): Promise<any|undefined> {
+export function getCLDefinition(object: string, library?: string): Promise<any | undefined> {
 	return connection.sendRequest("getCLDefinition", [object, library]);
 }
 
-export function getFileDefinition(object: string, library?: string): Promise<Files.ColumnDescription[]|undefined> {
+export function getFileDefinition(object: string, library?: string): Promise<Files.ColumnDescription[] | undefined> {
 	return connection.sendRequest("getFileDefinition", [object, library]);
+}
+
+export function getCLDoc(object: string, library?: string): Promise<DetailedCommandDoc | undefined> {
+	return connection.sendRequest("getCLDoc", [object, library]);
 }

--- a/server/src/instance.ts
+++ b/server/src/instance.ts
@@ -8,15 +8,10 @@ import {
 	TextDocument
 } from 'vscode-languageserver-textdocument';
 import { CLDoc, Files } from './spec';
-import { getCLDocSpec } from './data';
 
 // Create a connection for the server, using Node's IPC as a transport.
 // Also include all preview / proposed LSP features.
 export const connection = createConnection(ProposedFeatures.all);
-
-connection.onRequest("getCLDoc", async (qualifiedObject: string[]) => {
-	return await getCLDocSpec(qualifiedObject[0], qualifiedObject[1]);
-});
 
 // Create a simple text document manager.
 export const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);

--- a/server/src/providers/hover.ts
+++ b/server/src/providers/hover.ts
@@ -16,8 +16,8 @@ export default async function hoverProvider(params: HoverParams): Promise<Hover 
 				const command = statement.getObject();
 				if (command) {
 					const commandName = command.name.toUpperCase();
-					const detailedDoc = await getCLDocSpec(commandName, command.library);
-					if (!detailedDoc) {
+					const clDoc = await getCLDocSpec(commandName, command.library);
+					if (!clDoc) {
 						return;
 					}
 
@@ -30,13 +30,14 @@ export default async function hoverProvider(params: HoverParams): Promise<Hover 
 					});
 
 					// Check if hovering on a parameter
+					const viewFullDoc = `\n\n---\n\n[View Full Documentation](command:vscode-clle.viewFullDocumentation?${encodeURI(`["${commandName}"${command.library ? `,"${command.library}"` : ``}]`)})`;
 					if (currentParm) {
-						const parameterDoc = detailedDoc.parameters.find(p => p.name === currentParm);
+						const parameterDoc = clDoc.doc.parameters.find(p => p.name === currentParm);
 						if (parameterDoc && parameterDoc.description) {
 							return {
 								contents: {
 									kind: MarkupKind.Markdown,
-									value: `${parameterDoc.description}\n\n---\n\n[Search on IBM Documentation](https://www.ibm.com/docs/en/search)`
+									value: `${parameterDoc.description}${viewFullDoc}`
 								}
 							};
 						}
@@ -44,11 +45,11 @@ export default async function hoverProvider(params: HoverParams): Promise<Hover 
 						// Check if hovering on a command
 						const token = statement.getTokenByOffset(offset);
 						if (token && token.value && token.value.toUpperCase() === commandName) {
-							if (detailedDoc.command.description) {
+							if (clDoc.doc.command.description) {
 								return {
 									contents: {
 										kind: MarkupKind.Markdown,
-										value: `**${detailedDoc.command.name}**\n\n${detailedDoc.command.description}\n\n---\n\n[View Full Documentation](command:vscode-clle.viewFullDocumentation)`
+										value: `**${clDoc.doc.command.name}**\n\n${clDoc.doc.command.description}${viewFullDoc}`
 									}
 								};
 							}

--- a/server/src/providers/hover.ts
+++ b/server/src/providers/hover.ts
@@ -32,7 +32,7 @@ export default async function hoverProvider(params: HoverParams): Promise<Hover 
 					// Check if hovering on a parameter
 					const viewFullDoc = `\n\n---\n\n[View Full Documentation](command:vscode-clle.viewFullDocumentation?${encodeURI(`["${commandName}"${command.library ? `,"${command.library}"` : ``}]`)})`;
 					if (currentParm) {
-						const parameterDoc = clDoc.doc.parameters.find(p => p.name === currentParm);
+						const parameterDoc = clDoc.doc.parameters.details.find(p => p.name === currentParm);
 						if (parameterDoc && parameterDoc.description) {
 							return {
 								contents: {

--- a/server/src/providers/hover.ts
+++ b/server/src/providers/hover.ts
@@ -11,8 +11,8 @@ export default async function hoverProvider(params: HoverParams): Promise<Hover 
 		if (module) {
 			const offset = document.offsetAt(params.position);
 			const statement = module.getStatementByOffset(offset);
-
-			if (statement) {
+	
+			if (statement && offset >= statement.range.start && offset <= statement.range.end) {
 				const command = statement.getObject();
 				if (command) {
 					const commandName = command.name.toUpperCase();

--- a/server/src/providers/hover.ts
+++ b/server/src/providers/hover.ts
@@ -1,0 +1,61 @@
+import { Hover, HoverParams, MarkupKind } from 'vscode-languageserver';
+import { documents } from '../instance';
+import { CLModules, getCLDocSpec } from '../data';
+
+export default async function hoverProvider(params: HoverParams): Promise<Hover | undefined> {
+	const currentPath = params.textDocument.uri;
+	const document = documents.get(currentPath);
+
+	if (document) {
+		const module = CLModules[currentPath];
+		if (module) {
+			const offset = document.offsetAt(params.position);
+			const statement = module.getStatementByOffset(offset);
+
+			if (statement) {
+				const command = statement.getObject();
+				if (command) {
+					const commandName = command.name.toUpperCase();
+					const detailedDoc = await getCLDocSpec(commandName, command.library);
+					if (!detailedDoc) {
+						return;
+					}
+
+					// Parms in the existing statement
+					const currentParms = statement.getParms();
+
+					const currentParm = Object.keys(currentParms).find(parmKey => {
+						const block = currentParms[parmKey];
+						return (offset >= (block.range.start - parmKey.length) && offset <= block.range.end);
+					});
+
+					// Check if hovering on a parameter
+					if (currentParm) {
+						const parameterDoc = detailedDoc.parameters.find(p => p.name === currentParm);
+						if (parameterDoc && parameterDoc.description) {
+							return {
+								contents: {
+									kind: MarkupKind.Markdown,
+									value: `${parameterDoc.description}\n\n---\n\n[Search on IBM Documentation](https://www.ibm.com/docs/en/search)`
+								}
+							};
+						}
+					} else {
+						// Check if hovering on a command
+						const token = statement.getTokenByOffset(offset);
+						if (token && token.value && token.value.toUpperCase() === commandName) {
+							if (detailedDoc.command.description) {
+								return {
+									contents: {
+										kind: MarkupKind.Markdown,
+										value: `**${detailedDoc.command.name}**\n\n${detailedDoc.command.description}\n\n---\n\n[View Full Documentation](command:vscode-clle.viewFullDocumentation)`
+									}
+								};
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -25,6 +25,7 @@ import completionProvider from './providers/completion';
 import definitionProvider from './providers/definition';
 import documentSymbolProvider from './providers/documentSymbol';
 import { renameProvider, prepareRenameProvider } from './providers/rename';
+import hoverProvider from './providers/hover';
 import { referencesProvider } from './providers/reference';
 import { CLParser, Module } from 'language';
 import { CLModules } from './data';
@@ -63,7 +64,8 @@ connection.onInitialize((params: InitializeParams) => {
 			renameProvider: {
 				prepareProvider: true
 			},
-			referencesProvider: true
+			referencesProvider: true,
+			hoverProvider: true
 		}
 	};
 	if (hasWorkspaceFolderCapability) {
@@ -108,6 +110,7 @@ connection.onDocumentSymbol(documentSymbolProvider);
 connection.onPrepareRename(prepareRenameProvider);
 connection.onRenameRequest(renameProvider);
 connection.onReferences(referencesProvider);
+connection.onHover(hoverProvider);
 
 documents.onDidChangeContent((event: TextDocumentChangeEvent<TextDocument>) => {
 	const document = event.document;

--- a/server/src/spec.ts
+++ b/server/src/spec.ts
@@ -6,9 +6,14 @@ export interface CLDoc {
 		description: string
 	}
 	parameters: {
-		name: string;
-		description: string;
-	}[];
+		overview: string;
+		details: {
+			name: string;
+			description: string;
+		}[]
+	};
+	examples: string;
+	errorMessages: string;
 }
 
 export interface CommandDoc {

--- a/server/src/spec.ts
+++ b/server/src/spec.ts
@@ -1,6 +1,6 @@
 import { DataType, DefinitionType } from 'language';
 
-export interface DetailedCommandDoc {
+export interface CLDoc {
 	command: {
 		name: string;
 		description: string

--- a/server/src/spec.ts
+++ b/server/src/spec.ts
@@ -1,5 +1,16 @@
 import { DataType, DefinitionType } from 'language';
 
+export interface DetailedCommandDoc {
+	command: {
+		name: string;
+		description: string
+	}
+	parameters: {
+		name: string;
+		description: string;
+	}[];
+}
+
 export interface CommandDoc {
 	commandInfo: CommandInfo;
 	parms: Parameter[];

--- a/server/webpack.config.js
+++ b/server/webpack.config.js
@@ -13,5 +13,10 @@ module.exports = withDefaults({
     filename: `server.js`,
     path: path.join(__dirname, `..`, `out`)
   },
+  resolve: {
+      mainFields: [`module`, `main`],
+      extensions: [`.ts`, `.js`], // support ts-files and js-files
+			conditionNames: ['import', 'require'],
+  },
   plugins: [],
 });


### PR DESCRIPTION
**⚠️ This PR builds on https://github.com/IBM/vscode-clle/pull/46 so lets merge that one first before getting to this one. ⚠️**

### Changes
This PR adds a hover provider for CL commands and parameters. This information is retrieved using the `GENCMDDOC` command.  A new exported API was also added which includes a `GenCmdXml` namespace which has 2 APIs to generate and parse the html. As part of these changes, I also had to bump the `vscode-languageclient` to `^7.0.0` which in fact we wanted to do (#2). I simply undid https://github.com/IBM/vscode-clle/commit/b9e54711e7a2caa697f435cf5247d9e750f82a54 as mentioned in the issue.

**Hover on commands:**
<img width="2897" height="1297" alt="image" src="https://github.com/user-attachments/assets/b9936eab-8db7-428e-9cd4-10e5a4c622c1" />

**Hover on parameters:**
<img width="2577" height="1383" alt="image" src="https://github.com/user-attachments/assets/c38e02e0-0a48-4f95-8fca-ed637e6f5830" />

**Option to `View Full Documentation`**
<img width="742" height="228" alt="image" src="https://github.com/user-attachments/assets/670f7db9-a361-412a-9c89-9dd4a47a86ef" />

**Webview with full documentation**
<img width="3109" height="2195" alt="image" src="https://github.com/user-attachments/assets/fac23b60-5420-49b3-a16f-56dca961048e" />

<img width="3111" height="2121" alt="image" src="https://github.com/user-attachments/assets/781e3597-e7fc-4455-a974-036d9051e370" />
