### PR TITLE
Add parameter docs to content assist

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -21,7 +21,7 @@ import {
 } from 'vscode-languageserver-textdocument';
 
 import { connection, documents } from './instance';
-import completionProvider from './providers/completion';
+import { completionProvider, completionResolveProvider } from './providers/completion';
 import definitionProvider from './providers/definition';
 import documentSymbolProvider from './providers/documentSymbol';
 import { renameProvider, prepareRenameProvider } from './providers/rename';
@@ -57,7 +57,8 @@ connection.onInitialize((params: InitializeParams) => {
 			textDocumentSync: TextDocumentSyncKind.Incremental,
 			// Tell the client that this server supports code completion.
 			completionProvider: {
-				triggerCharacters: [`&`, `(`]
+				triggerCharacters: [`&`, `(`],
+				resolveProvider: true
 			},
 			definitionProvider: true,
 			documentSymbolProvider: true,
@@ -105,6 +106,7 @@ connection.onInitialized(() => {
 });
 
 connection.onCompletion(completionProvider);
+connection.onCompletionResolve(completionResolveProvider);
 connection.onDefinition(definitionProvider);
 connection.onDocumentSymbol(documentSymbolProvider);
 connection.onPrepareRename(prepareRenameProvider);


### PR DESCRIPTION
This PR builds on https://github.com/IBM/vscode-clle/pull/47, to add command docs to the content assist The current `completionProvider` is kept as is to load from `GENCMDXML`. A `completionResolveProvider` was added which will add the docs (this is done separately as the `GENCMDDOC` command takes longer to run).

Fixes #49

<img width="980" height="292" alt="image" src="https://github.com/user-attachments/assets/d288182a-4212-42b1-a10d-4ff183dae5db" />

<img width="1224" height="597" alt="image" src="https://github.com/user-attachments/assets/5e832072-cac3-4c02-bc4d-a8614cb39b97" />