### PR TITLE
Rename syntax checker and cl command docs components

### DIFF
--- a/client/src/components/gencmdxml/gencmdxml.ts
+++ b/client/src/components/gencmdxml/gencmdxml.ts
@@ -7,8 +7,8 @@ import { ExtensionContext } from 'vscode';
 
 export default class GenCmdXml implements IBMiComponent {
 	static ID = `GENCMDXML`;
-	static PGM_NAME = `GENCMD2`;
-	private readonly currentVersion = 1;
+	static PGM_NAME = `GENCMDXML`;
+	private readonly currentVersion = 2;
 	private library: string | undefined;
 
 	getIdentification(): ComponentIdentification {

--- a/client/src/components/syntaxChecker/checker.ts
+++ b/client/src/components/syntaxChecker/checker.ts
@@ -97,11 +97,8 @@ export class CLSyntaxChecker implements IBMiComponent {
       await content.writeStreamfileRaw(sqlPath, sqlBytes);
 
       // Drop existing UDTF specific (ignore failure)
-      const dropUdtf = `RUNSQL SQL('DROP SPECIFIC FUNCTION ${library}.${CLSyntaxChecker.UDTF_NAME}') COMMIT(*NONE) NAMING(*SYS)`;
-      const dropUdtfResult = await connection.runCommand({
-        command: dropUdtf,
-        noLibList: true
-      });
+      const dropUdtf = `DROP SPECIFIC FUNCTION ${library}.${CLSyntaxChecker.UDTF_NAME}`;
+      const dropUdtfResult = await connection.runSQL(dropUdtf);
 
       // Create UDTF
       const createUdtf = `RUNSQLSTM SRCSTMF('${sqlPath}') COMMIT(*NONE) NAMING(*SYS)`;

--- a/client/src/components/syntaxChecker/checker.ts
+++ b/client/src/components/syntaxChecker/checker.ts
@@ -24,11 +24,11 @@ export interface ClSyntaxError {
 
 export class CLSyntaxChecker implements IBMiComponent {
   static ID = "CLSyntaxChecker";
-  static UDTF_NAME = 'CL_SYNTAX_CHECK';
-  static PGM_NAME = 'COZCLCHECK';
+  static UDTF_NAME = 'CL_SYNTAX_CHECKER';
+  static PGM_NAME = 'CLSYNCHECK';
   static CHECK_INTERVAL = 1500;
   static MAX_DOCUMENT_LENGTH = 32740;
-  private readonly currentVersion = 1.1;
+  private readonly currentVersion = 2;
   private library: string | undefined;
 
   getIdentification(): ComponentIdentification {

--- a/client/src/components/syntaxChecker/checker.ts
+++ b/client/src/components/syntaxChecker/checker.ts
@@ -96,9 +96,13 @@ export class CLSyntaxChecker implements IBMiComponent {
       const sqlBytes = textEncoder.encode(sqlSource);
       await content.writeStreamfileRaw(sqlPath, sqlBytes);
 
-      // Drop existing UDTF specific (ignore failure)
+      // Drop existing UDTF specific
       const dropUdtf = `DROP SPECIFIC FUNCTION ${library}.${CLSyntaxChecker.UDTF_NAME}`;
-      const dropUdtfResult = await connection.runSQL(dropUdtf);
+      try {
+        const dropUdtfResult = await connection.runSQL(dropUdtf);
+      } catch (error) {
+        // Ignore error as UDTF may not exist
+      }
 
       // Create UDTF
       const createUdtf = `RUNSQLSTM SRCSTMF('${sqlPath}') COMMIT(*NONE) NAMING(*SYS)`;

--- a/client/src/components/syntaxChecker/cppSource.ts
+++ b/client/src/components/syntaxChecker/cppSource.ts
@@ -2,8 +2,8 @@ export function getCLCheckerCPPSrc() {
   return `
   // C++ processing program for QCAPCMD SQL Function
   // To compile:
-  //    CRTCPPMOD MODULE(CODE4I/COZ_CAPCMD) SRCFILE(CODE4I/QCSRC) SRCMBR(COZ_CAPCMD)
-  //    CRTPGM    PGM(CODE4I/COZ_CAPCMD) MODULE(CODE4I/COZ_CAPCMD)
+  //    CRTCPPMOD MODULE(ILEDITOR/CLSYNCHECK) SRCFILE(ILEDITOR/QCSRC) SRCMBR(CLSYNCHECK)
+  //    CRTPGM    PGM(ILEDITOR/CLSYNCHECK) MODULE(ILEDITOR/CLSYNCHECK)
 
   // be sure to replace the library with your own library name
 
@@ -479,7 +479,7 @@ int main(int argc, char *argv[])
 
       }
       const char lf = 0x25;
-      Qp0zLprintf("[COZCLCHECK] Using CL Syntax Check Option %s Process Type: %d %c",
+      Qp0zLprintf("[CLSYNCHECK] Using CL Syntax Check Option %s Process Type: %d %c",
                    inCHECKOPT,
                    ctrlBlock.Command_Process_Type,
                    lf);

--- a/client/src/components/syntaxChecker/readme.md
+++ b/client/src/components/syntaxChecker/readme.md
@@ -33,8 +33,8 @@ All notable changes to the CL Syntax Checker component are documented in this fi
 
 ### Added
 - CL Syntax Checker component for real-time CL statement validation
-- C++ module (`COZCLCHECK`) CL syntax validation module via the SQL UDTF
-- SQL UDTF (`CL_SYNTAX_CHECK`) for SQL-based syntax checking interface
+- C++ module (`CLSYNCHECK`) CL syntax validation module via the SQL UDTF
+- SQL UDTF (`CL_SYNTAX_CHECKER`) for SQL-based syntax checking interface
 - Integration with VS Code diagnostics system
 - Command registration for manual syntax checking (`vscode-clle.CLSyntaxCheck`)
 - Automatic installation of required IBM i components

--- a/client/src/components/syntaxChecker/udtfSource.ts
+++ b/client/src/components/syntaxChecker/udtfSource.ts
@@ -24,10 +24,10 @@ CREATE or REPLACE FUNCTION ${schema}.${CLSyntaxChecker.UDTF_NAME} (
 
 
 LABEL on specific routine ${schema}.CODE4IBMI_CLCHECK IS
-'CL command Syntax Check via QCAPCMD API';
+'CL Command Syntax Checker via QCAPCMD API';
 
 comment on specific FUNCTION ${schema}.CODE4IBMI_CLCHECK is
-'${version} - CL Command Syntax Checker. QCAPCMD Wrapper by Bob Cozzi.';
+'${version} - CL Command Syntax Checker (QCAPCMD Wrapper)';
 
 comment on parameter specific function ${schema}.CODE4IBMI_CLCHECK
 (

--- a/client/src/components/syntaxChecker/udtfSource.ts
+++ b/client/src/components/syntaxChecker/udtfSource.ts
@@ -18,18 +18,18 @@ CREATE or REPLACE FUNCTION ${schema}.${CLSyntaxChecker.UDTF_NAME} (
      FINAL CALL
      DISALLOW PARALLEL
      SCRATCHPAD 8400
-     SPECIFIC CODE4IBMI_CLCHECK
+     SPECIFIC ${CLSyntaxChecker.UDTF_NAME}
      EXTERNAL NAME '${schema}/${CLSyntaxChecker.PGM_NAME}'
      PARAMETER STYLE DB2SQL;
 
 
-LABEL on specific routine ${schema}.CODE4IBMI_CLCHECK IS
+LABEL on specific routine ${schema}.${CLSyntaxChecker.UDTF_NAME} IS
 'CL Command Syntax Checker via QCAPCMD API';
 
-comment on specific FUNCTION ${schema}.CODE4IBMI_CLCHECK is
+comment on specific FUNCTION ${schema}.${CLSyntaxChecker.UDTF_NAME} is
 '${version} - CL Command Syntax Checker (QCAPCMD Wrapper)';
 
-comment on parameter specific function ${schema}.CODE4IBMI_CLCHECK
+comment on parameter specific function ${schema}.${CLSyntaxChecker.UDTF_NAME}
 (
 CMD is 'The CL command to be checked. A command length of up to 6000
   bytes is supported by this function',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-clle",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-clle",
-			"version": "1.2.0",
+			"version": "1.2.1",
 			"hasInstallScript": true,
 			"dependencies": {
 				"vscode-languageclient": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "CL",
 	"description": "CLLE language tools",
 	"author": "IBM",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"publisher": "IBM",
 	"categories": [
 		"Programming Languages"


### PR DESCRIPTION
- Rename components
- Fix issue with updating CL syntax checker by first attempting to `DROP SPECIFIC FUNCTION...`