### PR TITLE
Move `DSPFFD` logic out of `GENCMDXML` and into utils

### DIFF
--- a/client/src/components/gencmdxml/gencmdxml.ts
+++ b/client/src/components/gencmdxml/gencmdxml.ts
@@ -22,7 +22,7 @@ export default class GenCmdXml implements IBMiComponent {
 			const componentManager = connection.getComponentManager();
 			const componentStates = componentManager.getComponentStates();
 			const genCmdXmlComponentState = componentStates.find(cs => cs.id.name === GenCmdXml.ID);
-			if (genCmdXmlComponentState.state === `Installed` || genCmdXmlComponentState.state === `NeedsUpdate`) {
+			if (genCmdXmlComponentState && (genCmdXmlComponentState.state === `Installed` || genCmdXmlComponentState.state === `NeedsUpdate`)) {
 				const allAvailableComponents = componentManager.getAllAvailableComponents();
 				const genCmdXmlComponent = allAvailableComponents.find(ac => ac.getIdentification().name === GenCmdXml.ID) as GenCmdXml;
 				if (genCmdXmlComponent) {
@@ -115,36 +115,6 @@ export default class GenCmdXml implements IBMiComponent {
 				}
 			} catch (e) {
 				console.log(e);
-			}
-		}
-	}
-
-	/**
-	 * Returns DSPFFD outfile rows
-	 */
-	async getFileDefinition(objectName: string, library = `*LIBL`): Promise<any | undefined> {
-		const instance = getInstance();
-		const connection = instance.getConnection();
-		if (connection) {
-			const content = connection.getContent();
-			const config = connection.getConfig();
-
-			const tempLib = config.tempLibrary;
-			const dateStr = Date.now().toString().substr(-6);
-			const randomFile = `R${objectName.substring(0, 3)}${dateStr}`.substring(0, 10);
-			const fullPath = `${tempLib}/${randomFile}`;
-
-			const outfileRes = await connection.runCommand({
-				command: `DSPFFD FILE(${library}/${objectName}) OUTPUT(*OUTFILE) OUTFILE(${fullPath})`,
-				environment: `ile`
-			});
-			console.log(outfileRes);
-			const resultCode = outfileRes.code || 0;
-
-			if (resultCode === 0) {
-				const data: object[] = await content.getTable(config.tempLibrary, randomFile, randomFile, true);
-				console.log(`Temp OUTFILE read. ${data.length} rows.`);
-				return data;
 			}
 		}
 	}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -9,6 +9,7 @@ import { registerCommands } from './commands';
 import GenCmdXml from './components/gencmdxml/gencmdxml';
 import { GenCmdDoc } from './gencmddoc';
 import Configuration from './configuration';
+import { getFileDefinition } from './utils';
 
 export interface CLLE {
 	genCmdDoc: GenCmdDoc
@@ -73,12 +74,8 @@ export function activate(context: ExtensionContext): CLLE {
 		});
 
 		client.onRequest("getFileDefinition", async (qualifiedObject: string[]) => {
-			const genCmdXml = GenCmdXml.get();
-			if (genCmdXml) {
-				const definition = await genCmdXml.getFileDefinition(qualifiedObject[0], qualifiedObject[1]);
-
-				return definition;
-			}
+			const definition = await getFileDefinition(qualifiedObject[0], qualifiedObject[1]);
+			return definition;
 		});
 
 		client.onRequest("getCLDoc", async (qualifiedObject: string[]) => {

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -1,4 +1,5 @@
 import { Selection, TextDocument, Range, EndOfLine } from 'vscode';
+import { getInstance } from './api/ibmi';
 
 export type CommandDetails = { content: string, range?: { start: number, end: number } };
 
@@ -64,4 +65,34 @@ function removePlusJoins(lines: string[]) {
   }
 
   return lines;
+}
+
+/**
+ * Returns DSPFFD outfile rows
+ */
+export async function getFileDefinition(objectName: string, library = `*LIBL`): Promise<any | undefined> {
+	const instance = getInstance();
+	const connection = instance.getConnection();
+	if (connection) {
+		const content = connection.getContent();
+		const config = connection.getConfig();
+
+		const tempLib = config.tempLibrary;
+		const dateStr = Date.now().toString().substr(-6);
+		const randomFile = `R${objectName.substring(0, 3)}${dateStr}`.substring(0, 10);
+		const fullPath = `${tempLib}/${randomFile}`;
+
+		const outfileRes = await connection.runCommand({
+			command: `DSPFFD FILE(${library}/${objectName}) OUTPUT(*OUTFILE) OUTFILE(${fullPath})`,
+			environment: `ile`
+		});
+		console.log(outfileRes);
+		const resultCode = outfileRes.code || 0;
+
+		if (resultCode === 0) {
+			const data: object[] = await content.getTable(config.tempLibrary, randomFile, randomFile, true);
+			console.log(`Temp OUTFILE read. ${data.length} rows.`);
+			return data;
+		}
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-clle",
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-clle",
-			"version": "1.2.2",
+			"version": "1.2.3",
 			"hasInstallScript": true,
 			"dependencies": {
 				"vscode-languageclient": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "CL",
 	"description": "CLLE language tools",
 	"author": "IBM",
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"publisher": "IBM",
 	"categories": [
 		"Programming Languages"


### PR DESCRIPTION
Fixes #58

This `getFileDefinition` logic is not reliant on GENCMDXML so need to ensure that component is installed for this to work. Moving logic to utils