### PR TITLE
Improve error handling when fetching CL command documentation

### DIFF
--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -10,9 +10,14 @@ export function registerCommands(context: ExtensionContext, client: LanguageClie
     }),
 
     commands.registerCommand(`vscode-clle.viewFullDocumentation`, async (object: string, library: string) => {
-      const isDocOpened = await GenCmdDoc.openClDoc(object, library);
-      if (!isDocOpened) {
-        await window.showErrorMessage(`Documentation for ${object} command not found`);
+      try {
+        const isDocOpened = await GenCmdDoc.openClDoc(object, library);
+        if (!isDocOpened) {
+          await window.showErrorMessage(`Documentation for ${object} command not found`);
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        await window.showErrorMessage(`Failed to generate documentation: ${errorMessage}`);
       }
     })
   )

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -16,8 +16,7 @@ export function registerCommands(context: ExtensionContext, client: LanguageClie
           await window.showErrorMessage(`Documentation for ${object} command not found`);
         }
       } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        await window.showErrorMessage(`Failed to generate documentation: ${errorMessage}`);
+        await window.showErrorMessage(`Failed to open documentation for ${object}/${library}`);
       }
     })
   )

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -85,7 +85,7 @@ export function activate(context: ExtensionContext): CLLE {
 					return await GenCmdDoc.getCLDoc(qualifiedObject[0], qualifiedObject[1]);
 				} catch (error) {
 					const errorMessage = error instanceof Error ? error.message : String(error);
-					console.error('Error getting CL documentation:', errorMessage);
+
 					// Return error object so caller knows what went wrong
 					return { error: errorMessage };
 				}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -83,8 +83,11 @@ export function activate(context: ExtensionContext): CLLE {
 			if (displayCommandDocumentation) {
 				try {
 					return await GenCmdDoc.getCLDoc(qualifiedObject[0], qualifiedObject[1]);
-				} catch (e) {
-					console.log(e);
+				} catch (error) {
+					const errorMessage = error instanceof Error ? error.message : String(error);
+					console.error('Error getting CL documentation:', errorMessage);
+					// Return error object so caller knows what went wrong
+					return { error: errorMessage };
 				}
 			}
 		});

--- a/client/src/gencmddoc.ts
+++ b/client/src/gencmddoc.ts
@@ -73,6 +73,9 @@ export class GenCmdDoc {
 			if (generateResult.code === 0) {
 				const html = (await content.downloadStreamfileRaw(`${toDir}/${toStmf}`)).toString();
 				return html;
+			} else {
+				// Throw stdout from the result when command fails
+				throw new Error(generateResult.stdout || `GENCMDDOC command failed with code ${generateResult.code}`);
 			}
 		}
 	}

--- a/server/src/data.ts
+++ b/server/src/data.ts
@@ -46,7 +46,7 @@ export async function getFileSpec(object: string, library = '*LIBL', openId?: st
 	return (spec ? Files.getVariables(spec, openId) : undefined);
 }
 
-export async function getCLDocSpec(object: string, library = '*LIBL'): Promise<{ html: string, doc: CLDoc } | undefined> {
+export async function getCLDocSpec(object: string, library = '*LIBL'): Promise<{ html: string, doc: CLDoc } | { error: string } | undefined> {
 	const validObject = object.toUpperCase();
 	const validLibrary = (library || `*LIBL`).toUpperCase();
 	return await getCLDoc(validObject, validLibrary);

--- a/server/src/instance.ts
+++ b/server/src/instance.ts
@@ -24,6 +24,6 @@ export function getFileDefinition(object: string, library?: string): Promise<Fil
 	return connection.sendRequest("getFileDefinition", [object, library]);
 }
 
-export function getCLDoc(object: string, library?: string): Promise<{ html: string, doc: CLDoc } | undefined> {
+export function getCLDoc(object: string, library?: string): Promise<{ html: string, doc: CLDoc } | { error: string } | undefined> {
 	return connection.sendRequest("getCLDoc", [object, library]);
 }

--- a/server/src/providers/completion.ts
+++ b/server/src/providers/completion.ts
@@ -150,23 +150,18 @@ export async function completionResolveProvider(item: CompletionItem): Promise<C
 
 	if (data && data.commandName && data.name) {
 		const clDoc = await getCLDocSpec(data.commandName, data.commandLibrary);
-
-		// Check if response contains an error
-		if (clDoc && 'error' in clDoc) {
-			console.error(`Failed to get CL documentation for ${data.commandName}: ${clDoc.error}`);
-			return item;
-		}
-
 		if (clDoc) {
-			const parameterDoc = clDoc.doc.parameters.details.find(p => p.name === data.name);
-			if (parameterDoc && parameterDoc.description) {
-				// Remove the heading pattern: ### Parameter\n\n
-				const description = parameterDoc.description.replace(/^###[^\n]*\n\n/, '');
+			if (!('error' in clDoc)) {
+				const parameterDoc = clDoc.doc.parameters.details.find(p => p.name === data.name);
+				if (parameterDoc && parameterDoc.description) {
+					// Remove the heading pattern: ### Parameter\n\n
+					const description = parameterDoc.description.replace(/^###[^\n]*\n\n/, '');
 
-				item.documentation = {
-					kind: MarkupKind.Markdown,
-					value: description
-				};
+					item.documentation = {
+						kind: MarkupKind.Markdown,
+						value: description
+					};
+				}
 			}
 		}
 	}

--- a/server/src/providers/completion.ts
+++ b/server/src/providers/completion.ts
@@ -151,6 +151,12 @@ export async function completionResolveProvider(item: CompletionItem): Promise<C
 	if (data && data.commandName && data.name) {
 		const clDoc = await getCLDocSpec(data.commandName, data.commandLibrary);
 
+		// Check if response contains an error
+		if (clDoc && 'error' in clDoc) {
+			console.error(`Failed to get CL documentation for ${data.commandName}: ${clDoc.error}`);
+			return item;
+		}
+
 		if (clDoc) {
 			const parameterDoc = clDoc.doc.parameters.details.find(p => p.name === data.name);
 			if (parameterDoc && parameterDoc.description) {

--- a/server/src/providers/hover.ts
+++ b/server/src/providers/hover.ts
@@ -20,6 +20,12 @@ export default async function hoverProvider(params: HoverParams): Promise<Hover 
 					if (!clDoc) {
 						return;
 					}
+					
+					// Check if response contains an error
+					if ('error' in clDoc) {
+						console.error(`Failed to get CL documentation for ${commandName}: ${clDoc.error}`);
+						return;
+					}
 
 					// Parms in the existing statement
 					const currentParms = statement.getParms();

--- a/server/src/providers/hover.ts
+++ b/server/src/providers/hover.ts
@@ -21,9 +21,7 @@ export default async function hoverProvider(params: HoverParams): Promise<Hover 
 						return;
 					}
 					
-					// Check if response contains an error
 					if ('error' in clDoc) {
-						console.error(`Failed to get CL documentation for ${commandName}: ${clDoc.error}`);
 						return;
 					}
 


### PR DESCRIPTION
@SanjulaGanepola @Mohammed-Yaseen-Ali-2081 

This PR is to catch the error message returned in GENCMDDOC, whereas earlier we are just returning if code ===0. Now we are throwing the error message.