### PR TITLE
Fix retrieval of CL syntax checker component

### DIFF
--- a/client/src/components/gencmdxml/gencmdxml.ts
+++ b/client/src/components/gencmdxml/gencmdxml.ts
@@ -22,7 +22,7 @@ export default class GenCmdXml implements IBMiComponent {
 			const componentManager = connection.getComponentManager();
 			const componentStates = componentManager.getComponentStates();
 			const genCmdXmlComponentState = componentStates.find(cs => cs.id.name === GenCmdXml.ID);
-			if (genCmdXmlComponentState && (genCmdXmlComponentState.state === `Installed` || genCmdXmlComponentState.state === `NeedsUpdate`)) {
+			if (genCmdXmlComponentState && (genCmdXmlComponentState.state.status === `Installed` || genCmdXmlComponentState.state.status === `NeedsUpdate`)) {
 				const allAvailableComponents = componentManager.getAllAvailableComponents();
 				const genCmdXmlComponent = allAvailableComponents.find(ac => ac.getIdentification().name === GenCmdXml.ID) as GenCmdXml;
 				if (genCmdXmlComponent) {

--- a/client/src/components/syntaxChecker/checker.ts
+++ b/client/src/components/syntaxChecker/checker.ts
@@ -35,10 +35,10 @@ export class CLSyntaxChecker implements IBMiComponent {
     return { name: CLSyntaxChecker.ID, version: this.currentVersion };
   }
 
-  static get(): CLSyntaxChecker | undefined {
+  static async get(): Promise<CLSyntaxChecker | undefined> {
     const instance = getInstance();
     const connection = instance?.getConnection();
-    return connection?.getComponent<CLSyntaxChecker>(CLSyntaxChecker.ID);
+    return await connection?.getComponent<CLSyntaxChecker>(CLSyntaxChecker.ID);
   }
 
   async getRemoteState(connection: IBMi, installDirectory: string): Promise<ComponentState> {

--- a/client/src/components/syntaxChecker/problemProvider.ts
+++ b/client/src/components/syntaxChecker/problemProvider.ts
@@ -31,10 +31,10 @@ export namespace ProblemProvider {
         }
       }),
 
-      workspace.onDidOpenTextDocument(e => {
+      workspace.onDidOpenTextDocument(async e => {
         const isSupportedLanguage = SUPPORTED_LANGUAGE_IDS.includes(e.languageId as SupportedLanguageId);
         if (isSupportedLanguage) {
-          if (checkerAvailable() && !isSafeDocument(e)) {
+          if (await checkerAvailable() && !isSafeDocument(e)) {
             const basename = e.fileName ? path.basename(e.fileName) : `Untitled`;
             documentLargeError(basename);
           }
@@ -46,13 +46,13 @@ export namespace ProblemProvider {
         }
       }),
 
-      workspace.onDidChangeTextDocument(e => {
+      workspace.onDidChangeTextDocument(async e => {
         shiftDiagnostics(e.document, e.contentChanges);
 
         const isSupportedLanguage = SUPPORTED_LANGUAGE_IDS.includes(e.document.languageId as SupportedLanguageId);
         if (isSupportedLanguage) {
           const checkOnChange = Configuration.get<boolean>(`syntax.checkOnEdit`) || false;
-          if (checkerAvailable() && checkOnChange && e.contentChanges.length > 0) {
+          if (await checkerAvailable() && checkOnChange && e.contentChanges.length > 0) {
             if (currentTimeout) {
               clearTimeout(currentTimeout);
             }
@@ -158,7 +158,7 @@ export namespace ProblemProvider {
   }
 
   async function validateCLDocument(document: TextDocument, specificLines?: number[]) {
-    const checker = CLSyntaxChecker.get();
+    const checker = await CLSyntaxChecker.get();
     if (checker) {
       const basename = document.fileName ? path.basename(document.fileName) : `Untitled`;
       if (isSafeDocument(document)) {
@@ -267,12 +267,12 @@ export namespace ProblemProvider {
     return isSupportedLanguage && isBelowMaxLength;
   }
 
-  function checkerAvailable() {
-    return CLSyntaxChecker.get() !== undefined;
+  async function checkerAvailable() {
+    return await CLSyntaxChecker.get() !== undefined;
   }
 
-  export function setCheckerAvailableContext(additionalState = true) {
-    const available = checkerAvailable() && additionalState;
+  export async function setCheckerAvailableContext(additionalState = true) {
+    const available = await checkerAvailable() && additionalState;
     commands.executeCommand(`setContext`, `vscode-clle.syntax.checkerAvailable`, available);
   }
 


### PR DESCRIPTION
### Changes

This depends on Code for IBM i 3.0.0 being release first.

Code for IBM i's `getComponent` returns a `Promise` in `3.0.0` so we should make use of `await` when retrieving it.